### PR TITLE
Chrisdev

### DIFF
--- a/cdqforcelayout/cdqforcelayoutcmd.py
+++ b/cdqforcelayout/cdqforcelayoutcmd.py
@@ -7,6 +7,7 @@ import traceback
 import json
 import logging
 from contextlib import redirect_stdout
+import numpy as np
 
 import ndex2
 from cdqforcelayout import qflayout
@@ -135,7 +136,8 @@ def run_layout(theargs, out_stream=sys.stdout,
                                                 a_radius=theargs.a_radius,
                                                 r_scale=theargs.r_scale,
                                                 a_scale=theargs.a_scale,
-                                                center_attractor_scale=theargs.center_attractor_scale)
+                                                center_attractor_scale=theargs.center_attractor_scale,
+                                                dtype=np.int)
             new_layout = qfl.do_layout(rounds=theargs.rounds)
             # write value of cartesianLayout aspect to output stream
             logger.debug(str(new_layout))

--- a/cdqforcelayout/cdqforcelayoutcmd.py
+++ b/cdqforcelayout/cdqforcelayoutcmd.py
@@ -7,7 +7,6 @@ import traceback
 import json
 import logging
 from contextlib import redirect_stdout
-import numpy as np
 
 import ndex2
 from cdqforcelayout import qflayout
@@ -137,7 +136,7 @@ def run_layout(theargs, out_stream=sys.stdout,
                                                 r_scale=theargs.r_scale,
                                                 a_scale=theargs.a_scale,
                                                 center_attractor_scale=theargs.center_attractor_scale,
-                                                dtype=np.int)
+                                                dtype=int)
             new_layout = qfl.do_layout(rounds=theargs.rounds)
             # write value of cartesianLayout aspect to output stream
             logger.debug(str(new_layout))

--- a/cdqforcelayout/qflayout.py
+++ b/cdqforcelayout/qflayout.py
@@ -3,9 +3,9 @@
 # and parameters for the algorithm.
 #
 import numpy as np
-from . import qfnetwork
+from cdqforcelayout import qfnetwork
 from math import sqrt
-from .qfields import repulsion_field, attraction_field, add_field, subtract_field
+from cdqforcelayout.qfields import repulsion_field, attraction_field, add_field, subtract_field
 import logging
 
 

--- a/cdqforcelayout/test_script.py
+++ b/cdqforcelayout/test_script.py
@@ -2,9 +2,15 @@ import os
 import sys
 import ndex2
 import json
-
 from numpy import int32
-from . import qflayout
+
+# this path insert enables one to invoke this
+# script from this directory and use the other
+# modules in the cdqforcelayout package
+sys.path.insert(0, os.path.abspath('../'))
+
+from cdqforcelayout import qflayout
+
 
 NDEXUSER = "dexterpratt"
 NDEXPASSWORD = "cytoscaperules"
@@ -16,11 +22,11 @@ def upload_network(cx_network):
     print("Network's URL (click to view!): " + SERVER + "/viewer/networks/" + url)
 
 def load_test_cx(filename):
-    parent_dir = os.path.dirname(os.path.dirname(__file__))
+    parent_dir = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
     path = os.path.join(parent_dir, "tests", "data", filename)
     return ndex2.create_nice_cx_from_file(path)
 
-parent_dir = os.path.dirname(os.path.dirname(__file__))
+parent_dir = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
 ncipid_path = os.path.join(parent_dir, "tests", "ncipid")
 ncipid_files = [f for f in os.listdir(ncipid_path) if os.path.isfile(os.path.join(ncipid_path, f))]
 ncipid_networks = []

--- a/cdqforcelayout/test_script.py
+++ b/cdqforcelayout/test_script.py
@@ -4,9 +4,15 @@ import ndex2
 import json
 from numpy import int32
 
-# this path insert enables one to invoke this
-# script from this directory and use the other
-# modules in the cdqforcelayout package
+# the sys.path.insert enables invocation of this
+# script from this directory and allows usage the other
+# modules in this cdqforcelayout package
+#
+# WARNING: If cdqforcelayout is pip installed and this
+#          script is called, this script may use
+#          the installed modules instead of these.
+#          YOU HAVE BEEN WARNED
+#
 sys.path.insert(0, os.path.abspath('../'))
 
 from cdqforcelayout import qflayout


### PR DESCRIPTION
added `sys.path.insert(os.path.abspath('../'))`  at top of `test_script.py` so this script can be run from the cdqforcelayout package and leverage the modules in the current directory. 

**WARNING: if cdqforcelayout package is installed via pip then those modules may be used instead of ones in the current directory **

Added `os.path.abspath()` around `__file__` calls so the `os.path.dirname` calls would work correctly. 
